### PR TITLE
Added missing order attribute

### DIFF
--- a/src/app/Models/Menu.php
+++ b/src/app/Models/Menu.php
@@ -12,7 +12,7 @@ class Menu extends Model
 {
     use FormattedTimestamps, DbSyncMigrations;
 
-    protected $fillable = ['name', 'icon', 'link', 'has_children', 'parent_id'];
+    protected $fillable = ['name', 'icon', 'order', 'link', 'has_children', 'parent_id'];
 
     protected $attributes = ['order' => 999, 'has_children' => false];
 


### PR DESCRIPTION
Added missing `order` attribute in the `$fillable` property which fixes a problem when updating and saving menu order