### PR TITLE
Fix formating dates

### DIFF
--- a/src/app/Tables/Templates/menus.json
+++ b/src/app/Tables/Templates/menus.json
@@ -47,13 +47,13 @@
             "label": "Created At",
             "name": "created_at",
             "data": "menus.created_at",
-            "meta": ["sortable"]
+            "meta": ["sortable", "date"]
         },
         {
             "label": "Updated At",
             "name": "updated_at",
             "data": "menus.updated_at",
-            "meta": ["sortable"]
+            "meta": ["sortable", "date"]
         }
     ]
 }


### PR DESCRIPTION
You forgot to specify meta "date" for Menu Table.

Same story for **permissionmanager**, **rolemanager**, **localisation** repos.