### PR TITLE
Update Menu model to always cast parent_id to int

### DIFF
--- a/src/app/Models/Menu.php
+++ b/src/app/Models/Menu.php
@@ -15,7 +15,10 @@ class Menu extends Model
         'name', 'icon', 'order_index', 'link', 'has_children', 'parent_id',
     ];
 
-    protected $casts = ['has_children' => 'boolean'];
+    protected $casts = [
+        'has_children' => 'boolean',
+        'parent_id' => 'integer',
+    ];
 
     public function parent()
     {


### PR DESCRIPTION
Some database drivers implicitly convert (non-primary?) keys to string.

This caused a mismatch in the hasChildren check breaking submenus